### PR TITLE
Build a grpc4bmi server for Hydrotrend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# A grpc4bmi server for the `Hydrotrend` model.
+FROM csdms/grpc4bmi:0.3.0
+
+LABEL org.opencontainers.image.authors="Mark Piper <mark.piper@colorado.edu>"
+LABEL org.opencontainers.image.source="https://github.com/csdms/hydrotrend-grpc4bmi"
+
+RUN git clone --branch v3.1.4 --depth 1 https://github.com/csdms-contrib/hydrotrend /opt/hydrotrend
+WORKDIR /opt/hydrotrend/_build
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
+    make && \
+    ctest -V && \
+    make install && \
+    make clean
+
+COPY server /opt/hydrotrend-grpc4bmi-server
+WORKDIR /opt/hydrotrend-grpc4bmi-server/_build
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
+    make && \
+    make install && \
+    make clean
+
+WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,6 @@ RUN cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_DIR} && \
     make clean
 
 WORKDIR /opt
+
+ENTRYPOINT ["/opt/conda/bin/hydrotrend-grpc4bmi-server"]
+EXPOSE 55555

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
 # hydrotrend-grpc4bmi
-Run the Hydrotrend model through grpc4bmi
+
+Set up a [grpc4bmi](https://grpc4bmi.readthedocs.io) server
+to run a containerized version
+of the [HydroTrend](https://csdms.colorado.edu/wiki/Model:HydroTrend) model
+through Python.
+
+## Build
+
+Build this example locally with:
+```
+docker build --tag hydrotrend-grpc4bmi .
+```
+The image is built on the [csdms/grpc4bmi](https://hub.docker.com/r/csdms/grpc4bmi) base image,
+which is built on the [condaforge/miniforge3](https://hub.docker.com/r/condaforge/miniforge3) base image.
+The OS is Linux/Ubuntu.
+The HydroTrend model, grpc4bmi, and the grpc4bmi server are installed in `/opt/conda`.
+The HydroTrend grpc4bmi server is exposed through port 55555.
+
+## Run
+
+Use the grpc4bmi Docker client to access the BMI methods of the containerized model.
+
+Install with *pip*:
+```
+pip install grpc4bmi
+```
+Then, in a Python session, access HydroTrend in the image built above with:
+```python
+from grpc4bmi.bmi_client_docker import BmiClientDocker
+
+
+m = BmiClientDocker(image="hydrotrend-grpc4bmi", image_port=55555, work_dir=".")
+m.get_component_name()
+
+del m  # stop container cleanly
+```
+
+If the image isn't found locally, it's pulled from Docker Hub
+(e.g., try the `csdms/hydrotrend-grpc4bmi` image).
+
+For more in-depth examples of running the HydroTrend model through grpc4bmi,
+see the [examples](./examples) directory.
+
+## Acknowledgment
+
+This work is supported by the U.S. National Science Foundation under Award No. [2103878](https://www.nsf.gov/awardsearch/showAward?AWD_ID=2103878), *Frameworks: Collaborative Research: Integrative Cyberinfrastructure for Next-Generation Modeling Science*.

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,0 +1,45 @@
+# hydrotrend-grpc4bmi
+
+cmake_minimum_required(VERSION 3.16)
+project(hydrotrend-grpc4bmi
+  VERSION 0.1.0
+  LANGUAGES CXX
+)
+
+include(GNUInstallDirs)
+
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(HYDROTREND REQUIRED IMPORTED_TARGET hydrotrend)
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
+message(STATUS "Include directory: ${HYDROTREND_INCLUDE_DIRS}")
+message(STATUS "Library path: ${HYDROTREND_LINK_LIBRARIES}")
+list(POP_BACK CMAKE_MESSAGE_INDENT)
+
+pkg_check_modules(PROTOBUF REQUIRED IMPORTED_TARGET protobuf)
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
+message(STATUS "Include directory: ${PROTOBUF_INCLUDE_DIRS}")
+message(STATUS "Library path: ${PROTOBUF_LINK_LIBRARIES}")
+list(POP_BACK CMAKE_MESSAGE_INDENT)
+
+pkg_check_modules(GRPC4BMI REQUIRED IMPORTED_TARGET grpc4bmi)
+list(APPEND CMAKE_MESSAGE_INDENT "  ")
+message(STATUS "Include directory: ${GRPC4BMI_INCLUDE_DIRS}")
+message(STATUS "Library path: ${GRPC4BMI_LINK_LIBRARIES}")
+list(POP_BACK CMAKE_MESSAGE_INDENT)
+
+set(server_exe hydrotrend-grpc4bmi-server)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -lgrpc++_reflection")
+
+add_executable(${server_exe} ${server_exe}.cxx)
+target_link_libraries(${server_exe}
+  ${HYDROTREND_LINK_LIBRARIES}
+  ${PROTOBUF_LINK_LIBRARIES}
+  ${GRPC4BMI_LINK_LIBRARIES}
+)
+target_include_directories(${server_exe} PUBLIC ${GRPC4BMI_INCLUDE_DIRS})
+
+install(
+  TARGETS ${server_exe}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)

--- a/server/hydrotrend-grpc4bmi-server.cxx
+++ b/server/hydrotrend-grpc4bmi-server.cxx
@@ -1,0 +1,24 @@
+#include <stdio.h>
+
+#include "bmi_hydrotrend.h"
+#include "bmi_grpc_server.h"
+
+
+int main(int argc, char *argv[])
+{
+    printf("BmiHydrotrend grpc4bmi server\n");
+
+    Bmi *model = (Bmi *) malloc(sizeof(Bmi));
+
+    register_bmi_hydrotrend(model);
+
+    {
+        char model_name[BMI_MAX_COMPONENT_NAME];
+        
+        model->get_component_name(model, model_name);
+        printf("%s\n", model_name);
+    }
+
+    free(model);
+    return 0;
+}

--- a/server/hydrotrend-grpc4bmi-server.cxx
+++ b/server/hydrotrend-grpc4bmi-server.cxx
@@ -19,6 +19,8 @@ int main(int argc, char *argv[])
         printf("%s\n", model_name);
     }
 
+    run_bmi_server(model, argc, argv);
+
     free(model);
     return 0;
 }

--- a/server/hydrotrend-grpc4bmi-server.cxx
+++ b/server/hydrotrend-grpc4bmi-server.cxx
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-#include "bmi_hydrotrend.h"
+#include "hydrotrend/bmi_hydrotrend.h"
 #include "bmi_grpc_server.h"
 
 


### PR DESCRIPTION
This PR adds a grpc4bmi server for Hydrotrend. It's structured as an analogue to the "conda-base" version of the [grpc4bmi server for the C BMI example](https://github.com/csdms/bmi-example-c-grpc4bmi). 

Note that while the software in this image is built on conda packages, I had to build Hydrotrend from source because the *hydrotrend* package on conda-forge doesn't include binaries for linux-aarch64. 